### PR TITLE
[HMINT-387] Add Validation for Negative Token Ids

### DIFF
--- a/src/contracts/EVMContract.ts
+++ b/src/contracts/EVMContract.ts
@@ -150,8 +150,13 @@ export class EVMContract extends BaseContract implements IContract {
         } else {
             if (tokenId === undefined) {
                 this.logger.log('getTokenBalance', 'Token id required', true);
+            } else if (tokenId < 0) {
+                this.logger.log(
+                    'getTokenBalance',
+                    'Token id must be non-negative',
+                    true
+                );
             }
-
             balance = await contract.balanceOf(
                 await signer.getAddress(),
                 tokenId


### PR DESCRIPTION
## Overview
Add validation for negative token ids.

## Note
When no token id is passed in, the console no longer throws the following error:
```
client-sdk-evm.js:7596 Uncaught (in promise) Error: invalid BigNumber string (argument="value", value="", code=INVALID_ARGUMENT, version=bignumber/5.6.2)
```
Instead a `Token id required` error is thrown as intended.

## Demo
When passing in a token id of `-1`:

https://user-images.githubusercontent.com/126987566/226034339-c1df8473-a03f-45fa-aec4-a2713c9c1a71.mov

