### PR TITLE
[HMINT-536] Fix Source Map Error in Console

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 /* eslint-disable @typescript-eslint/no-var-requires */
-const mix = require('laravel-mix');
+const mix = require('laravel-mix')
 
 // TODO: need to use mix.ts here to get proper typescript build checks
 mix.js('src/client-sdk-evm.ts', 'dist')
@@ -33,5 +33,6 @@ mix.js('src/client-sdk-evm.ts', 'dist')
                     loader: 'ts-loader'
                 }
             ]
-        }
-    });
+        },
+        devtool: 'source-map'
+    })


### PR DESCRIPTION
## Overview
This PR attempts to fix the source map error `DevTools failed to load source map: Could not parse content for https://hypermint.com/client-sdk/xml-http-request.js.map:` in console.

## Note
The other two console errors can be removed simply by disabling the Loom chrome extension 🙃 

## Demo
<details close>

<summary style="font-size:14px">Before</summary>

https://user-images.githubusercontent.com/126987566/227119642-3be3e079-c60a-46aa-9984-f28c6b75043a.mov


</details>

<details close>

<summary style="font-size:14px">After</summary>

https://user-images.githubusercontent.com/126987566/227119666-24d696be-5318-4132-b67f-631a84acc7f3.mov

</details>