### PR TITLE
adds walletUserMetadata to IWalletProvider for metadata from provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "@hypermint/client-sdk",
             "dependencies": {
-                "@moonpay/login-sdk": "^0.0.17",
+                "@moonpay/login-sdk": "^0.0.19",
                 "@solana/web3.js": "1.48.0",
                 "@walletconnect/client": "^1.8.0",
                 "@walletconnect/ethereum-provider": "^1.8.0",
@@ -2771,9 +2771,9 @@
             "integrity": "sha512-E286nmFoZNotV7AJ15VL5WcHbW+eT922505Fn3W93qua3774SVWiknAtHRH4I7kKOVWY+K3Ky3kc0kJorO7XsA=="
         },
         "node_modules/@moonpay/login-sdk": {
-            "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/@moonpay/login-sdk/-/login-sdk-0.0.17.tgz",
-            "integrity": "sha512-vf74cR5qDxjKcSzjInW3fWR4u9B72Hmkpl/FOYaytWpnD9Ujp34HqCutYfdItt/Fqv3sc8IXj9zOQ7fXiGXXnw==",
+            "version": "0.0.19",
+            "resolved": "https://registry.npmjs.org/@moonpay/login-sdk/-/login-sdk-0.0.19.tgz",
+            "integrity": "sha512-B/cmxSiXFEY9Z9pm9UebuULwZ0isViGqR0Nmj568RbnQ2qlXJ/2zJVMP7fwJx6DpWpi532DoD1zO5ucVTQ0cHw==",
             "dependencies": {
                 "@ethersproject/providers": "5.7.2",
                 "@moonpay/login-common": "*",
@@ -20393,9 +20393,9 @@
             "integrity": "sha512-E286nmFoZNotV7AJ15VL5WcHbW+eT922505Fn3W93qua3774SVWiknAtHRH4I7kKOVWY+K3Ky3kc0kJorO7XsA=="
         },
         "@moonpay/login-sdk": {
-            "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/@moonpay/login-sdk/-/login-sdk-0.0.17.tgz",
-            "integrity": "sha512-vf74cR5qDxjKcSzjInW3fWR4u9B72Hmkpl/FOYaytWpnD9Ujp34HqCutYfdItt/Fqv3sc8IXj9zOQ7fXiGXXnw==",
+            "version": "0.0.19",
+            "resolved": "https://registry.npmjs.org/@moonpay/login-sdk/-/login-sdk-0.0.19.tgz",
+            "integrity": "sha512-B/cmxSiXFEY9Z9pm9UebuULwZ0isViGqR0Nmj568RbnQ2qlXJ/2zJVMP7fwJx6DpWpi532DoD1zO5ucVTQ0cHw==",
             "requires": {
                 "@ethersproject/providers": "5.7.2",
                 "@moonpay/login-common": "*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "example": "npx serve ./src/example"
     },
     "dependencies": {
-        "@moonpay/login-sdk": "^0.0.17",
+        "@moonpay/login-sdk": "^0.0.19",
         "@solana/web3.js": "1.48.0",
         "@walletconnect/client": "^1.8.0",
         "@walletconnect/ethereum-provider": "^1.8.0",

--- a/src/contracts/EVMContract.ts
+++ b/src/contracts/EVMContract.ts
@@ -61,19 +61,24 @@ export class EVMContract extends BaseContract implements IContract {
                 ? await contract.balanceOf(address)
                 : await signer.getBalance();
 
+            const walletUserMetadata =
+                (await this.wallet.getWalletUserData()) || {};
+
             return {
                 isConnected: true,
                 address,
                 balance: {
                     value: balance,
                     formatted: formatEther(balance)
-                }
+                },
+                walletUserMetadata
             };
         } catch (e) {
             return {
                 isConnected: false,
                 address: undefined,
-                balance: undefined
+                balance: undefined,
+                walletUserMetadata: undefined
             };
         }
     }
@@ -138,6 +143,17 @@ export class EVMContract extends BaseContract implements IContract {
             );
         }
         return signer;
+    }
+
+    public getWalletUserData(): object | undefined {
+        const userWalletData = this.wallet.getWalletUserData();
+        if (userWalletData) {
+            this.logger.log(
+                'getWalletUserData',
+                `Wallet user data ${JSON.stringify(userWalletData, null, 4)}`
+            );
+        }
+        return userWalletData;
     }
 
     public setSigner(signer?: ethers.Signer): void {

--- a/src/example/index.html
+++ b/src/example/index.html
@@ -88,6 +88,7 @@
     <button onclick="contract.getTestWETH(0.3)">Get 0.1 test WETH</button>
     <button onclick="contract.getWalletBalance()">Get Wallet Balance</button>
     <button onclick="contract.getSigner()">Get Signer</button>
+    <button onclick="contract.getWalletUserData()">Get Wallet User Data</button>
   </div>
 
   <div class="section">

--- a/src/types/IWalletProvider.ts
+++ b/src/types/IWalletProvider.ts
@@ -2,4 +2,5 @@ import { ethers } from 'ethers';
 
 export interface IWalletProvider {
     getWeb3Provider: () => Promise<ethers.providers.Web3Provider>;
+    getWalletUserData?: () => object
 }

--- a/src/types/Wallet.ts
+++ b/src/types/Wallet.ts
@@ -5,4 +5,5 @@ export interface IConnectedWallet {
         value: string;
         formatted: string;
     };
+    walletUserMetadata?: object;
 }

--- a/src/wallets/Wallet.ts
+++ b/src/wallets/Wallet.ts
@@ -45,6 +45,13 @@ export class Wallet {
         this._signer = signer;
     }
 
+    public getWalletUserData() {
+        if (!this._provider.getWeb3Provider) {
+            throw new Error('Wallet not connected');
+        }
+        return this._provider.getWalletUserData();
+    }
+
     public async getWeb3Provider(): Promise<Web3Provider> {
         if (!this._web3Provider) {
             await this.connect();

--- a/src/wallets/providers/MoonPayWalletProvider.ts
+++ b/src/wallets/providers/MoonPayWalletProvider.ts
@@ -4,17 +4,26 @@ import WalletProvider from './WalletProvider';
 import { ethers } from 'ethers';
 
 export default class MoonPayWalletProvider extends WalletProvider {
+    private sdk: MoonpayWalletSDK;
+
     public async getWeb3Provider() {
         const sdk = new MoonpayWalletSDK({
             loginDomain: 'https://buy-sandbox.moonpay.com',
             secureWalletDomain: 'https://web3.moonpay.com',
             apiKey: 'pk_test_123'
         });
-        await sdk.init();
+
+        this.sdk = sdk;
+
+        await this.sdk.init();
         const moonpayProvider: ethers.providers.Web3Provider = sdk.provider;
 
         // trigger login flow by requesting accounts
         await moonpayProvider.send('eth_accounts', []);
         return moonpayProvider;
+    }
+    public getWalletUserData() {
+        const userData = this.sdk.getWalletMetaData();
+        return userData;
     }
 }


### PR DESCRIPTION
Allows `IWalletProvider` to call the underlaying sdk's `getWalletUserData` method when it exists to return data that is at the connection level but is not a blockchain call.

This can/should be extended to return a signed version of the data so we can verify it later