### PR TITLE
Add support for passing a walletAddress to getMoonPayWidgetUrl

### DIFF
--- a/src/contracts/BaseContract.ts
+++ b/src/contracts/BaseContract.ts
@@ -225,9 +225,9 @@ export class BaseContract {
             this._config.contractType === NFTContractType.ERC721
                 ? `${contract.metadata.tokenUrl}${tokenId}`
                 : contract.metadata.tokenUrl.replace(
-                    '{id}',
-                    tokenId.toString()
-                );
+                      '{id}',
+                      tokenId.toString()
+                  );
 
         this.logger.log(
             'getTokenMetadataUrl',
@@ -239,10 +239,11 @@ export class BaseContract {
 
     public getTransactionExplorerUrl(hash: string): string {
         if (this._config.networkType === NetworkType.Solana) {
-            return `https://solscan.io/tx/${hash}${this._config.networkEnvironment === NetworkEnvironment.Testnet
-                ? '?cluster=devnet'
-                : ''
-                }`;
+            return `https://solscan.io/tx/${hash}${
+                this._config.networkEnvironment === NetworkEnvironment.Testnet
+                    ? '?cluster=devnet'
+                    : ''
+            }`;
         }
 
         switch (this._config.networkChain) {

--- a/src/contracts/BaseContract.ts
+++ b/src/contracts/BaseContract.ts
@@ -19,9 +19,16 @@ export class BaseContract {
         this.logger.setConfig(_config);
     }
 
-    public async getMoonPayWidgetUrl(tokenId: number): Promise<string> {
+    public async getMoonPayWidgetUrl(
+        tokenId: number,
+        walletAddress?: string
+    ): Promise<string> {
         try {
-            const url = await HMAPI.getMoonPayWidgetUrl(this._config, tokenId);
+            const url = await HMAPI.getMoonPayWidgetUrl(
+                this._config,
+                tokenId,
+                walletAddress
+            );
 
             this.logger.log(
                 'getMoonPayWidgetUrl',
@@ -218,9 +225,9 @@ export class BaseContract {
             this._config.contractType === NFTContractType.ERC721
                 ? `${contract.metadata.tokenUrl}${tokenId}`
                 : contract.metadata.tokenUrl.replace(
-                      '{id}',
-                      tokenId.toString()
-                  );
+                    '{id}',
+                    tokenId.toString()
+                );
 
         this.logger.log(
             'getTokenMetadataUrl',
@@ -232,11 +239,10 @@ export class BaseContract {
 
     public getTransactionExplorerUrl(hash: string): string {
         if (this._config.networkType === NetworkType.Solana) {
-            return `https://solscan.io/tx/${hash}${
-                this._config.networkEnvironment === NetworkEnvironment.Testnet
-                    ? '?cluster=devnet'
-                    : ''
-            }`;
+            return `https://solscan.io/tx/${hash}${this._config.networkEnvironment === NetworkEnvironment.Testnet
+                ? '?cluster=devnet'
+                : ''
+                }`;
         }
 
         switch (this._config.networkChain) {

--- a/src/example/index.html
+++ b/src/example/index.html
@@ -146,17 +146,17 @@
     } = HyperMint;
 
     const contract = new Contract({
-      contractId: 'bf19ddc9-05ab-44cb-ba43-a777de280b3a',
+      // Enter your contract Id here
+      contractId: '',
       enableLogging: true,
       logger,
-      hmURL: "http://localhost:4001/v1"
-    });
+  });
 
     const authenticate = new Authenticate({
-      appId: '075f57a8-65dc-477e-9a8e-0ea19bbdbd52',
+      // Enter your authenticate appId here
+      appId: '',
       enableLogging: true,
       logger,
-      hmURL: "http://localhost:4001/v1"
     });
   </script>
 
@@ -194,7 +194,12 @@
     }
 
     async function openWidget(tokenId) {
-      window.open(await contract.getMoonPayWidgetUrl(tokenId));
+      window.open(
+        await contract.getMoonPayWidgetUrl(
+          tokenId,
+          (await contract.getConnectedWallet()).address
+        )
+      );
     }
   </script>
 </body>

--- a/src/example/index.html
+++ b/src/example/index.html
@@ -146,15 +146,15 @@
     } = HyperMint;
 
     const contract = new Contract({
-      // Enter your contract Id here
-      contractId: '',
+      // Enter your contract Id here or copy from the "Developers" section on your contract
+      contractId: 'bf19ddc9-05ab-44cb-ba43-a777de280b3a',
       enableLogging: true,
       logger,
   });
 
     const authenticate = new Authenticate({
-      // Enter your authenticate appId here
-      appId: '',
+      // Enter your authenticate appId here or copy from the "Developers" section on your authentication app
+      appId: '075f57a8-65dc-477e-9a8e-0ea19bbdbd52',
       enableLogging: true,
       logger,
     });

--- a/src/example/index.html
+++ b/src/example/index.html
@@ -147,7 +147,7 @@
 
     const contract = new Contract({
       // Enter your contract Id here or copy from the "Developers" section on your contract
-      contractId: 'bf19ddc9-05ab-44cb-ba43-a777de280b3a',
+      contractId: 'ee20b68e-356c-4547-bac1-2ccee24a47cd',
       enableLogging: true,
       logger,
     });

--- a/src/example/index.html
+++ b/src/example/index.html
@@ -150,7 +150,7 @@
       contractId: 'bf19ddc9-05ab-44cb-ba43-a777de280b3a',
       enableLogging: true,
       logger,
-  });
+    });
 
     const authenticate = new Authenticate({
       // Enter your authenticate appId here or copy from the "Developers" section on your authentication app

--- a/src/helpers/HMAPI.ts
+++ b/src/helpers/HMAPI.ts
@@ -138,11 +138,12 @@ export class HMAPI {
 
     public static async getMoonPayWidgetUrl(
         config: ContractConfig,
-        tokenId: number
+        tokenId: number,
+        walletAddress?: string,
     ): Promise<string> {
         const url = `${HMAPI.getHMBaseUrl(config)}/moonpay/widget/${
             config.contractId
-        }/${tokenId}`;
+        }/${tokenId}${walletAddress ? `?walletAddress=${walletAddress}` : ""}`;
 
         const result = await fetch(url);
 

--- a/src/helpers/HMAPI.ts
+++ b/src/helpers/HMAPI.ts
@@ -143,7 +143,9 @@ export class HMAPI {
     ): Promise<string> {
         const url = `${HMAPI.getHMBaseUrl(config)}/moonpay/widget/${
             config.contractId
-        }/${tokenId}${walletAddress ? `?walletAddress=${walletAddress}` : ""}`;
+        }/${tokenId}${
+            walletAddress ? `?walletAddress=${walletAddress}` : ""
+        }`;
 
         const result = await fetch(url);
 

--- a/src/types/IContractEvm.ts
+++ b/src/types/IContractEvm.ts
@@ -51,7 +51,10 @@ export interface IContract {
         amount?: number
     ) => Promise<Transaction>;
 
-    getMoonPayWidgetUrl: (tokenId: number) => Promise<string>;
+    getMoonPayWidgetUrl: (
+        tokenId: number,
+        walletAddress?: string
+    ) => Promise<string>;
 
     burn: (
         tokenId: number,

--- a/src/types/IContractSolana.ts
+++ b/src/types/IContractSolana.ts
@@ -49,5 +49,8 @@ export interface IContract {
         amount?: number
     ) => Promise<Transaction>;
 
-    getMoonPayWidgetUrl: (tokenId: number) => Promise<string>;
+    getMoonPayWidgetUrl: (
+        tokenId: number,
+        walletAddress?: string
+    ) => Promise<string>;
 }


### PR DESCRIPTION
Currently the SDK does not allow for a walletAddress param to be passed to the getMoonPayWidgetUrlfunction, even though the API supports it.

This PR will easily enable this for developers.